### PR TITLE
feat: add responsive header with mega menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,181 @@
+---
+---
+
+<header class="bg-white shadow">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="flex justify-between items-center h-16">
+      <a href="/" class="text-2xl font-bold text-blue-800">Avantys</a>
+      <nav class="hidden md:flex space-x-6">
+        <div class="relative group">
+          <button class="flex items-center gap-1 text-gray-700 hover:text-blue-600">
+            Comienza
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
+          </button>
+          <div class="absolute left-0 top-full hidden group-hover:block bg-white shadow-lg mt-2 p-6 w-screen max-w-4xl">
+            <div class="grid grid-cols-4 gap-8">
+              <div class="col-span-1">
+                <h3 class="text-lg font-semibold mb-2">Tu sitio web más rápido y seguro</h3>
+                <p class="text-sm text-gray-600">Descubre nuestro hosting web con cPanel, Cloudlinux y LiteSpeed en discos SSD NVMe.</p>
+                <a href="#" class="text-blue-600 hover:underline mt-2 inline-block text-sm">Más información</a>
+              </div>
+              <div class="col-span-1">
+                <h4 class="font-semibold text-gray-700 mb-2">Dominios</h4>
+                <ul class="space-y-2 text-sm">
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">Comprar Dominio</a></li>
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">Transferir Dominio</a></li>
+                </ul>
+              </div>
+              <div class="col-span-1">
+                <h4 class="font-semibold text-gray-700 mb-2">Hosting</h4>
+                <ul class="space-y-2 text-sm">
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">Hosting Wordpress</a></li>
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">Hosting Web</a></li>
+                </ul>
+              </div>
+              <div class="col-span-1">
+                <h4 class="font-semibold text-gray-700 mb-2">Buscar dominio</h4>
+                <input type="text" placeholder="Buscar dominio" class="w-full border rounded-md px-2 py-1 focus:outline-none focus:ring" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="relative group">
+          <button class="flex items-center gap-1 text-gray-700 hover:text-blue-600">
+            Crea
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
+          </button>
+          <div class="absolute left-0 top-full hidden group-hover:block bg-white shadow-lg mt-2 p-6 w-screen max-w-4xl">
+            <div class="grid grid-cols-3 gap-8">
+              <div>
+                <h4 class="font-semibold text-gray-700 mb-2">Desarrollo Web</h4>
+                <p class="text-sm text-gray-600">Webs que conectan, convencen y convierten.</p>
+              </div>
+              <div>
+                <h4 class="font-semibold text-gray-700 mb-2">Creador de webs gratuito</h4>
+                <p class="text-sm text-gray-600">Creatividad visual que impulsa tu marca al siguiente nivel.</p>
+              </div>
+              <div>
+                <h4 class="font-semibold text-gray-700 mb-2">Más información</h4>
+                <a href="#" class="text-blue-600 hover:underline text-sm">Saber más</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="relative group">
+          <button class="flex items-center gap-1 text-gray-700 hover:text-blue-600">
+            Crece
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
+          </button>
+          <div class="absolute left-0 top-full hidden group-hover:block bg-white shadow-lg mt-2 p-6 w-screen max-w-4xl">
+            <div class="grid grid-cols-3 gap-8">
+              <div>
+                <h4 class="font-semibold text-gray-700 mb-2">Growth 360</h4>
+                <p class="text-sm text-gray-600">Estrategias digitales que impulsan tu marca hacia el éxito en línea.</p>
+              </div>
+              <div>
+                <h4 class="font-semibold text-gray-700 mb-2">Redes Sociales</h4>
+                <p class="text-sm text-gray-600">Conecta, interactúa y crece con tu audiencia.</p>
+              </div>
+              <div>
+                <h4 class="font-semibold text-gray-700 mb-2">Marketing Deportivo</h4>
+                <p class="text-sm text-gray-600">Gestión de presencia digital de eventos y campañas.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="relative group">
+          <button class="flex items-center gap-1 text-gray-700 hover:text-blue-600">
+            Transforma
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
+          </button>
+          <div class="absolute left-0 top-full hidden group-hover:block bg-white shadow-lg mt-2 p-6 w-screen max-w-4xl">
+            <div class="grid grid-cols-4 gap-8">
+              <div class="col-span-1">
+                <h4 class="font-semibold text-gray-700 mb-2">Cloud</h4>
+                <ul class="space-y-2 text-sm">
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">Instancias Cloud</a></li>
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">Instancias dedicadas Cloud</a></li>
+                </ul>
+              </div>
+              <div class="col-span-1">
+                <h4 class="font-semibold text-gray-700 mb-2">Servidores</h4>
+                <ul class="space-y-2 text-sm">
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">VPS Linux</a></li>
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">VPS Windows</a></li>
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">VPS Trader</a></li>
+                </ul>
+              </div>
+              <div class="col-span-1">
+                <h4 class="font-semibold text-gray-700 mb-2">Administración de servidores</h4>
+                <ul class="space-y-2 text-sm">
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">Instalación y soporte 24/7</a></li>
+                </ul>
+              </div>
+              <div class="col-span-1">
+                <h4 class="font-semibold text-gray-700 mb-2">Paneles de Control</h4>
+                <ul class="space-y-2 text-sm">
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">cPanel</a></li>
+                  <li><a href="#" class="text-gray-600 hover:text-blue-600">Plesk</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </nav>
+      <div class="hidden md:block">
+        <a href="#" class="px-4 py-2 border border-blue-600 rounded-full text-blue-700 font-semibold hover:bg-blue-50">Área del cliente</a>
+      </div>
+      <div class="md:hidden flex items-center">
+        <button id="menu-btn" class="text-gray-700 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div id="mobile-menu" class="md:hidden hidden border-t">
+    <div class="px-4 py-4 space-y-4">
+      <details>
+        <summary class="font-semibold cursor-pointer">Comienza</summary>
+        <div class="mt-2 space-y-2 text-sm">
+          <a href="#" class="block text-gray-600">Comprar Dominio</a>
+          <a href="#" class="block text-gray-600">Transferir Dominio</a>
+          <a href="#" class="block text-gray-600">Hosting Wordpress</a>
+          <a href="#" class="block text-gray-600">Hosting Web</a>
+        </div>
+      </details>
+      <details>
+        <summary class="font-semibold cursor-pointer">Crea</summary>
+        <div class="mt-2 space-y-2 text-sm">
+          <a href="#" class="block text-gray-600">Desarrollo Web</a>
+          <a href="#" class="block text-gray-600">Creador de webs gratuito</a>
+        </div>
+      </details>
+      <details>
+        <summary class="font-semibold cursor-pointer">Crece</summary>
+        <div class="mt-2 space-y-2 text-sm">
+          <a href="#" class="block text-gray-600">Growth 360</a>
+          <a href="#" class="block text-gray-600">Redes Sociales</a>
+          <a href="#" class="block text-gray-600">Marketing Deportivo</a>
+        </div>
+      </details>
+      <details>
+        <summary class="font-semibold cursor-pointer">Transforma</summary>
+        <div class="mt-2 space-y-2 text-sm">
+          <a href="#" class="block text-gray-600">Cloud</a>
+          <a href="#" class="block text-gray-600">Servidores</a>
+          <a href="#" class="block text-gray-600">Administración de servidores</a>
+          <a href="#" class="block text-gray-600">Paneles de control</a>
+        </div>
+      </details>
+      <a href="#" class="block px-4 py-2 border border-blue-600 rounded-full text-blue-700 text-center font-semibold">Área del cliente</a>
+    </div>
+  </div>
+  <script type="module">
+    const btn = document.getElementById('menu-btn');
+    const menu = document.getElementById('mobile-menu');
+    btn?.addEventListener('click', () => {
+      menu.classList.toggle('hidden');
+    });
+  </script>
+</header>
+

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import Header from "../components/Header.astro";
 ---
 
 <html lang="es">
@@ -8,6 +9,7 @@ import "../styles/global.css";
     <title>Avantys Web</title>
   </head>
   <body class="bg-gray-100 text-gray-900">
+    <Header />
     <slot />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add responsive Header component with Tailwind-based mega menus and mobile navigation
- include Header in base layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bacd3662e48321a14680a8eedcacdd