### PR TITLE
feat: add responsive header with mega menus

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,188 @@
+---
+interface Link {
+  href: string;
+  label: string;
+  desc?: string;
+}
+
+interface Section {
+  title: string;
+  links: Link[];
+}
+
+interface NavItem {
+  label: string;
+  promo?: { title: string; desc: string; cta: { href: string; label: string } };
+  sections: Section[];
+}
+
+const navItems: NavItem[] = [
+  {
+    label: 'Comienza',
+    promo: {
+      title: 'Tu sitio web más rápido y seguro',
+      desc: 'Descubre nuestro hosting web con cPanel, Cloudlinux y LiteSpeed en discos SSD NVMe.',
+      cta: { href: '/hosting', label: 'Más información' }
+    },
+    sections: [
+      {
+        title: 'Dominios',
+        links: [
+          { href: '/dominios/comprar', label: 'Comprar Dominio', desc: 'Elige y registra el dominio ideal para tu proyecto.' },
+          { href: '/dominios/transferir', label: 'Transferir Dominio', desc: 'Transfiere tu dominio sin complicaciones.' }
+        ]
+      },
+      {
+        title: 'Hosting',
+        links: [
+          { href: '/hosting/wordpress', label: 'Hosting WordPress', desc: 'WordPress optimizado: rápido y seguro.' },
+          { href: '/hosting/web', label: 'Hosting Web', desc: 'Hosting robusto para sitios dinámicos.' }
+        ]
+      }
+    ]
+  },
+  {
+    label: 'Crea',
+    promo: {
+      title: 'Sobre Avantys',
+      desc: 'Descubre nuestras soluciones de alojamiento web con cPanel, Cloudlinux y LiteSpeed.',
+      cta: { href: '/sobre-nosotros', label: 'Más información' }
+    },
+    sections: [
+      {
+        title: 'Servicios',
+        links: [
+          { href: '/desarrollo-web', label: 'Desarrollo Web', desc: 'Webs que conectan y convierten.' },
+          { href: '/creador-web', label: 'Creador de webs gratuito', desc: 'Crea tu sitio visualmente.' }
+        ]
+      }
+    ]
+  },
+  {
+    label: 'Crece',
+    promo: {
+      title: 'Sobre Avantys',
+      desc: 'Nuestro servicio de administración te brinda tranquilidad y soporte 24/7.',
+      cta: { href: '/sobre-nosotros', label: 'Más información' }
+    },
+    sections: [
+      {
+        title: 'Marketing',
+        links: [
+          { href: '/growth-360', label: 'Growth 360', desc: 'Estrategias digitales integrales.' },
+          { href: '/redes-sociales', label: 'Redes Sociales', desc: 'Gestionamos tu comunidad.' },
+          { href: '/marketing-deportivo', label: 'Marketing Deportivo', desc: 'Soluciones para el ámbito deportivo.' }
+        ]
+      }
+    ]
+  },
+  {
+    label: 'Transforma',
+    promo: {
+      title: 'Sobre Avantys',
+      desc: 'Descubre nuestras soluciones para impulsar y proteger tu negocio en la nube.',
+      cta: { href: '/sobre-nosotros', label: 'Más información' }
+    },
+    sections: [
+      {
+        title: 'Cloud',
+        links: [
+          { href: '/cloud', label: 'Cloud', desc: 'Infraestructura escalable y segura.' },
+          { href: '/administracion', label: 'Administración', desc: 'Gestionamos tus servidores 24/7.' }
+        ]
+      }
+    ]
+  }
+];
+---
+
+<header class="sticky top-0 z-50 bg-white border-b border-gray-200 shadow-sm">
+  <div class="max-w-7xl mx-auto px-4">
+    <div class="flex items-center justify-between h-16">
+      <a href="/" class="text-2xl font-bold text-blue-900 hover:text-blue-800">Avantys</a>
+
+      <button id="menu-btn" class="lg:hidden p-2 rounded-md text-gray-700 hover:text-gray-900 focus:outline-none" aria-label="Abrir menú" aria-controls="mobile-menu" aria-expanded="false">
+        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+      </button>
+
+      <nav class="hidden lg:flex items-center space-x-8">
+        {navItems.map(item => (
+          <div class="relative group">
+            <button class="flex items-center px-3 py-2 text-gray-700 hover:text-gray-900 font-medium transition-colors" aria-haspopup="true" aria-expanded="false">
+              {item.label}
+              <svg class="ml-1 h-4 w-4 transform group-hover:rotate-180 transition-transform" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>
+            </button>
+            <div class="absolute left-1/2 top-full w-screen max-w-5xl -translate-x-1/2 z-50 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200">
+              <div class="bg-white border border-gray-200 rounded-lg shadow-xl mt-2 p-8 grid grid-cols-12 gap-6">
+                {item.promo && (
+                  <div class="col-span-4 bg-gray-50 rounded-lg p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-4">{item.promo.title}</h3>
+                    <p class="text-sm text-gray-600 mb-4">{item.promo.desc}</p>
+                    <a href={item.promo.cta.href} class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium">
+                      {item.promo.cta.label}
+                      <svg class="ml-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    </a>
+                  </div>
+                )}
+                <div class="col-span-8 grid grid-cols-2 gap-6">
+                  {item.sections.map(section => (
+                    <div>
+                      <h4 class="text-lg font-semibold text-gray-900 mb-4">{section.title}</h4>
+                      <ul class="space-y-4">
+                        {section.links.map(link => (
+                          <li>
+                            <a href={link.href} class="block group">
+                              <h5 class="font-medium text-gray-900 group-hover:text-blue-600 transition-colors">{link.label}</h5>
+                              {link.desc && <p class="text-sm text-gray-500">{link.desc}</p>}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+        <a href="#" class="px-4 py-2 border border-blue-600 rounded-full text-blue-700 font-semibold hover:bg-blue-50">Área del cliente</a>
+      </nav>
+    </div>
+  </div>
+
+  <div id="mobile-menu" class="lg:hidden hidden border-t border-gray-200 bg-white">
+    <nav class="px-4 pt-4 pb-6 space-y-4">
+      {navItems.map(item => (
+        <details>
+          <summary class="flex items-center justify-between cursor-pointer py-2 text-gray-700 font-medium">
+            {item.label}
+            <svg class="h-4 w-4 ml-2" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>
+          </summary>
+          <div class="mt-2 space-y-4 pl-4">
+            {item.sections.map(section => (
+              <div>
+                <h4 class="font-semibold text-gray-900 mb-2">{section.title}</h4>
+                <ul class="space-y-1">
+                  {section.links.map(link => (
+                    <li><a href={link.href} class="block py-1 text-gray-700 hover:text-blue-600">{link.label}</a></li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </details>
+      ))}
+      <a href="#" class="block mt-2 px-4 py-2 border border-blue-600 rounded-full text-blue-700 font-semibold text-center">Área del cliente</a>
+    </nav>
+  </div>
+
+  <script>
+    const btn = document.getElementById('menu-btn');
+    const menu = document.getElementById('mobile-menu');
+    btn?.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', String(!expanded));
+      menu?.classList.toggle('hidden');
+    });
+  </script>
+</header>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import Header from "../components/Header.astro";
 ---
 
 <html lang="es">
@@ -8,6 +9,7 @@ import "../styles/global.css";
     <title>Avantys Web</title>
   </head>
   <body class="bg-gray-100 text-gray-900">
+    <Header />
     <slot />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- implement data-driven mega menu navigation with desktop and mobile layouts
- add hamburger toggle script for mobile menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bacd3662e48321a14680a8eedcacdd